### PR TITLE
feat(padded-describes): add the padded-describes rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+sudo: false
+node_js:
+  - '4'
+  - '5'
+script:
+  - npm test
+  - npm run lint
+after_script:
+  - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # eslint-plugin-lob
 
+[![Build Status](https://travis-ci.org/lob/eslint-plugin-lob.svg?branch=master)](https://travis-ci.org/lob/eslint-plugin-lob)
+[![Coverage Status](https://coveralls.io/repos/github/lob/eslint-plugin-lob/badge.svg?branch=master)](https://coveralls.io/github/lob/eslint-plugin-lob?branch=master)
+
 Custom ESLint rules for Lob repositories
 
 ## Installation
@@ -39,6 +42,10 @@ Then configure the rules you want to use under the rules section.
   }
 }
 ```
+
+## Supported Rules
+
+* `padded-describes` - `describe` blocks must be padded by blank lines
 
 ## Testing
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.rules = {
+  'padded-describes': require('./rules/padded-describes')
+};

--- a/lib/rules/padded-describes.js
+++ b/lib/rules/padded-describes.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const ERROR_MESSAGE = 'Describe blocks must be padded by blank lines.';
+
+/**
+ * Determine if provided nodeType is a function type.
+ * @private
+ * @param {String} nodeType - type to test
+ * @returns {Boolean} true if `nodeType` is a function type
+ */
+function isFunctionExpression (nodeType) {
+  return nodeType === 'FunctionExpression' || nodeType === 'ArrowFunctionExpression';
+}
+
+/**
+ * Checks if the given non empty block node is the callback of a describe function.
+ * @param {ASTNode} node - the AST node of a BlockStatement
+ * @returns {Boolean} whether or not the block is the callback of a describe function
+ */
+function isDescribeBlock (node) {
+  return isFunctionExpression(node.parent.type) &&
+    node.parent.parent.type === 'CallExpression' &&
+    node.parent.parent.callee.name === 'describe';
+}
+
+/**
+ * Checks if the location of a node or token is before the location of another node or token.
+ * @param {ASTNode|Token} a - the node or token to check if its location is before b
+ * @param {ASTNode|Token} b - the node or token which will be compared with a
+ * @returns {Boolean} true if a is located before b
+ */
+function isLocatedBefore (a, b) {
+  return a.range[1] < b.range[0];
+}
+
+module.exports = function (ctx) {
+  /**
+   * Checks if the given non empty block node has a blank line before its first child node.
+   * @param {ASTNode} node - the AST node of a BlockStatement
+   * @returns {Boolean} whether or not the block starts with a blank line
+   */
+  function isBlockTopPadded (node) {
+    const blockStart = node.loc.start.line;
+    const first = node.body[0];
+    const expectedFirstLine = blockStart + 2;
+    const leadingComments = (first.leadingComments || []).slice();
+    let firstLine = first.loc.start.line;
+
+    while (leadingComments.length > 0 && leadingComments[0].loc.start.line <= node.loc.start.line) {
+      leadingComments.shift();
+    }
+
+    const firstComment = leadingComments[0];
+
+    if (firstComment && isLocatedBefore(firstComment, first)) {
+      firstLine = firstComment.loc.start.line;
+    }
+
+    return expectedFirstLine <= firstLine;
+  }
+
+  /**
+   * Checks if the given non empty block node has a blank line after its last child node.
+   * @param {ASTNode} node - the AST node of a BlockStatement
+   * @returns {Boolean} whether or not the block ends with a blank line
+   */
+  function isBlockBottomPadded (node) {
+    const blockEnd = node.loc.end.line;
+    const last = node.body[node.body.length - 1];
+    const lastToken = ctx.getLastToken(last);
+    const expectedLastLine = blockEnd - 2;
+    const trailingComments = (last.trailingComments || []).slice();
+    let lastLine = lastToken.loc.end.line;
+
+    while (trailingComments.length > 0 && trailingComments[trailingComments.length - 1].loc.end.line >= node.loc.end.line) {
+      trailingComments.pop();
+    }
+
+    const lastComment = trailingComments[trailingComments.length - 1];
+
+    if (lastComment && isLocatedBefore(lastToken, lastComment)) {
+      lastLine = lastComment.loc.end.line;
+    }
+
+    return lastLine <= expectedLastLine;
+  }
+
+  return {
+    BlockStatement: (node) => {
+      if (node.body.length > 0 && isDescribeBlock(node)) {
+        const blockHasTopPadding = isBlockTopPadded(node);
+        const blockHasBottomPadding = isBlockBottomPadded(node);
+
+        if (!blockHasTopPadding) {
+          ctx.report(node, ERROR_MESSAGE);
+        }
+
+        if (!blockHasBottomPadding) {
+          ctx.report({
+            node,
+            loc: { line: node.loc.end.line, column: node.loc.end.column - 1 },
+            message: ERROR_MESSAGE
+          });
+        }
+      }
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "main": "lib/index.js",
   "scripts": {
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "eslint --ignore-path .gitignore .",
     "release:major": "changelog -M && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version major && git push origin && git push origin --tags",
     "release:minor": "changelog -m && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version minor && git push origin && git push origin --tags",
@@ -23,7 +24,7 @@
   "dependencies": {},
   "devDependencies": {
     "eslint": "^1.10.3",
-    "eslint-config-lob": "^1.1.0",
+    "eslint-config-lob": "^1.1.2",
     "generate-changelog": "^1.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5"

--- a/test/rules/padded-describes.test.js
+++ b/test/rules/padded-describes.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+
+const Rule = require('../../lib/rules/padded-describes');
+
+const Tester = new RuleTester({ ecmaFeatures: { arrowFunctions: true } });
+
+const ERROR_MESSAGE = 'Describe blocks must be padded by blank lines.';
+
+Tester.run('padded-describes', Rule, {
+  valid: [
+    'describe("", function () {});',
+    'describe("", function () {\n\nvar a = "";\n\n});',
+    'describe("", function () {\n\n// comment\n\n});',
+    'describe("", function () {\n\n/* comment */\n\n});',
+    'describe("", function () { // comment\n\nvar a = "";\n\n});',
+    'describe("", function () {\n\nvar a = "";\n\n/* comment */ });',
+    'describe("", () => {\n\nvar a = "";\n\n});',
+    'it("", function () {\n\nvar a = "";\n\n});',
+    'it("", function () {\nvar a = "";\n});',
+    'it("", function () { var a = ""; });',
+    'var a = function () {};',
+    'function a () {}',
+    '(function () {})(function () {});'
+  ],
+  invalid: [{
+    code: 'describe("", function () { var a = ""; });',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", function () {\nvar a = "";\n});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 3 }]
+  }, {
+    code: 'describe("", function () {\n\nvar a = "";\n});',
+    errors: [{ message: ERROR_MESSAGE }]
+  }, {
+    code: 'describe("", function () {\nvar a = "";\n\n});',
+    errors: [{ message: ERROR_MESSAGE }]
+  }, {
+    code: 'describe("", function () {\n// comment\nvar a = "";\n});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 4 }]
+  }, {
+    code: 'describe("", function () {\n/* comment */ var a = "";\n});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 3 }]
+  }, {
+    code: 'describe("", function () {\nvar a = "";\n// comment\n});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 4 }]
+  }, {
+    code: 'describe("", function () {\nvar a = ""; /* comment */\n});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 3 }]
+  }, {
+    code: 'describe("", () => { var a = ""; });',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", () => {\nvar a = "";\n});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 3 }]
+  }, {
+    code: 'describe("", () => {\n\nvar a = "";\n});',
+    errors: [{ message: ERROR_MESSAGE }]
+  }, {
+    code: 'describe("", () => {\nvar a = "";\n\n});',
+    errors: [{ message: ERROR_MESSAGE }]
+  }]
+});


### PR DESCRIPTION
### What

Create the `padded-describes` rule.

Creating a plugin is the way to create custom rules and then this new plugin will be required from https://github.com/lob/eslint-config-lob and then added to the config to be applied everywhere.

Most of this code is ripped from the [`padded-blocks`](https://github.com/eslint/eslint/blob/master/lib/rules/padded-blocks.js) rule in the core eslint repo. My main contribution is the `isDescribeBlock` function.

It was kinda hard to wrap my head around all of the AST node stuff, but the main helper for me to make sure I was doing the right thing was looking at the tests. If you have any additional test cases you want me to add, just let me know.

@mgartner 