### PR TITLE
feat(newline-after-mocha): add the newline-after-mocha rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
 exports.rules = {
+  'newline-after-mocha': require('./rules/newline-after-mocha'),
   'padded-describes': require('./rules/padded-describes')
 };

--- a/lib/rules/newline-after-mocha.js
+++ b/lib/rules/newline-after-mocha.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const ERROR_MESSAGE = 'It and describe blocks must be separated by new lines.';
+
+function isMochaCall (node) {
+  return node.callee.name === 'it' ||
+    node.callee.name === 'describe' ||
+    node.callee.name === 'beforeEach' ||
+    node.callee.name === 'afterEach' ||
+    node.callee.name === 'before' ||
+    node.callee.name === 'after';
+}
+
+function isLastNode (node) {
+  return node.parent.body[node.parent.body.length - 1] === node;
+}
+
+module.exports = function (ctx) {
+  return {
+    CallExpression: (node) => {
+      const statement = node.parent;
+
+      if (!isMochaCall(node)) {
+        return;
+      }
+
+      if (isLastNode(statement)) {
+        return;
+      }
+
+      const lastToken = ctx.getLastToken(statement);
+      const nextToken = ctx.getTokenAfter(statement);
+      const expectedNextLineNum = lastToken.loc.end.line + 1;
+      const hasNewLine = nextToken.loc.start.line > expectedNextLineNum;
+
+      if (!hasNewLine) {
+        ctx.report(node, ERROR_MESSAGE, { identifier: node.name });
+      }
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {},
   "devDependencies": {
     "eslint": "^1.10.3",
-    "eslint-config-lob": "^1.1.2",
+    "eslint-config-lob": "^2.0.0",
     "generate-changelog": "^1.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5"

--- a/test/rules/newline-after-mocha.test.js
+++ b/test/rules/newline-after-mocha.test.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+
+const Rule = require('../../lib/rules/newline-after-mocha');
+
+const Tester = new RuleTester({ ecmaFeatures: { arrowFunctions: true } });
+
+const ERROR_MESSAGE = 'It and describe blocks must be separated by new lines.';
+
+Tester.run('newline-after-mocha', Rule, {
+  valid: [
+    'it("", function () {});\n\nit("", function () {});',
+    'describe("", function () {});\n\ndescribe("", function () {});',
+    'it("", function () {});\n\ndescribe("", function () {});',
+    'describe("", function () {});\n\nit("", function () {});',
+    'beforeEach("", function () {});\n\nbeforeEach("", function () {});',
+    'afterEach("", function () {});\n\nafterEach("", function () {});',
+    'before("", function () {});\n\nbefore("", function () {});',
+    'after("", function () {});\n\nafter("", function () {});',
+    'describe("", function () {\nit("", function () {});\n\nit("", function () {});\n});',
+    'a("", function () {});\nb("", function () {});',
+    'it("", () => {});\n\nit("", () => {});',
+    'describe("", () => {});\n\ndescribe("", () => {});',
+    'it("", () => {});\n\ndescribe("", () => {});',
+    'describe("", () => {});\n\nit("", () => {});',
+    'beforeEach("", () => {});\n\nbeforeEach("", () => {});',
+    'afterEach("", () => {});\n\nafterEach("", () => {});',
+    'before("", () => {});\n\nbefore("", () => {});',
+    'after("", () => {});\n\nafter("", () => {});',
+    'describe("", () => {\nit("", () => {});\n\nit("", () => {});\n});',
+    'a("", () => {});\nb("", () => {});',
+    'var a = b();'
+  ],
+  invalid: [{
+    code: 'it("", function () {});it("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", function () {});describe("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'it("", function () {});describe("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", function () {});it("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'beforeEach("", function () {});beforeEach("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'afterEach("", function () {});afterEach("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'before("", function () {});before("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'after("", function () {});after("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'it("", function () {});\nit("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", function () {});\ndescribe("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'it("", function () {});\ndescribe("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", function () {});\nit("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'beforeEach("", function () {});\nbeforeEach("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'afterEach("", function () {});\nafterEach("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'before("", function () {});\nbefore("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'after("", function () {});\nafter("", function () {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", function () {\nit("", function () {});it("", function () {});\n});',
+    errors: [{ message: ERROR_MESSAGE, line: 2 }]
+  }, {
+    code: 'describe("", function () {\nit("", function () {});\nit("", function () {});\n});',
+    errors: [{ message: ERROR_MESSAGE, line: 2 }]
+  }, {
+    code: 'it("", () => {});it("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", () => {});describe("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'it("", () => {});describe("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", () => {});it("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'beforeEach("", () => {});beforeEach("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'afterEach("", () => {});afterEach("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'before("", () => {});before("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'after("", () => {});after("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'it("", () => {});\nit("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", () => {});\ndescribe("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'it("", () => {});\ndescribe("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", () => {});\nit("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'beforeEach("", () => {});\nbeforeEach("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'afterEach("", () => {});\nafterEach("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'before("", () => {});\nbefore("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'after("", () => {});\nafter("", () => {});',
+    errors: [{ message: ERROR_MESSAGE, line: 1 }]
+  }, {
+    code: 'describe("", () => {\nit("", () => {});it("", () => {});\n});',
+    errors: [{ message: ERROR_MESSAGE, line: 2 }]
+  }, {
+    code: 'describe("", () => {\nit("", () => {});\nit("", () => {});\n});',
+    errors: [{ message: ERROR_MESSAGE, line: 2 }]
+  }]
+});


### PR DESCRIPTION
### What

Adds the `newlint-after-mocha` rule that enforces new lines in between mocha blocks (`describe`, `it`, `beforeEach`, etc). This is based off of the default [`newline-after-var` rule](https://github.com/eslint/eslint/blob/master/lib/rules/newline-after-var.js) That makes this valid (without `padded-describes`):

```js
describe('controller', () => {
  beforeEach(() => {
  });

  it('test1', () => {
  });

  it('test2', () => {
  });
});
```

And this invalid:

```js
describe('controller', () => {
  beforeEach(() => {
  });
  it('test1', () => {
  });
  it('test2', () => {
  });
});
```

### Details

The reason most of the logic is centered around the `statement` (which is `node.parent`) instead of `node` is because every mocha call (`it('', () => {});`) is structured as an `ExpressionStatement` with a nested `CallExpression`, so two `it` blocks next to each other looks like this:

```
Program
├── ExpressionStatement
│   └── CallExpression
└── ExpressionStatement
    └── CallExpression
```

So by registering the rule function under `CallExpression` (which is necessary because the info about the name of the function is on the `CallExpression`), to know if it's the last call (since you don't want to enforce the new line rule if it's the last call), you need to see if the `ExpressionStatement` is the last child of `Program`.

The actual logic of the rule takes the last token of the statement (usually the semi-colon) and the first token after the statement (usually the next `it`) and makes sure the next token is at least 2 lines greater than the last token. And the tests cover all of our normal cases so I think it all works fine.

Hopefully that makes sense. If not, I can explain it further IRL.

@mgartner 