### PR TITLE
feat(align-requires): add align-requires rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Then configure the rules you want to use under the rules section.
 
 ## Supported Rules
 
+* `align-equals` - equal signs of variable declarations involving `require` or `Factory.build` must be aligned
+* `newline-after-mocha` - new lines must be between mocha blocks (`describe`, `it`, `beforeEach`, etc)
 * `padded-describes` - `describe` blocks must be padded by blank lines
 
 ## Testing

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 exports.rules = {
+  'align-equals': require('./rules/align-equals'),
   'newline-after-mocha': require('./rules/newline-after-mocha'),
   'padded-describes': require('./rules/padded-describes')
 };

--- a/lib/rules/align-equals.js
+++ b/lib/rules/align-equals.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const ERROR_MESSAGE = '{{error}} {{plural}} {{position}} equals for variable \'{{variable}}\'.';
+
+function isRequire (declaration) {
+  return declaration.init &&
+    declaration.init.type === 'CallExpression' &&
+    declaration.init.callee.name === 'require';
+}
+
+function isFactoryBuild (declaration) {
+  return declaration.init &&
+    declaration.init.type === 'CallExpression' &&
+    declaration.init.callee.object && declaration.init.callee.object.name === 'Factory' &&
+    declaration.init.callee.property && declaration.init.callee.property.name === 'build';
+}
+
+module.exports = function (ctx) {
+  const expectedEqualsLocations = [];
+
+  function getNextEqual (node) {
+    while (node && (node.type !== 'Punctuator' || node.value !== '=')) {
+      node = ctx.getTokenAfter(node);
+    }
+
+    return node;
+  }
+
+  function populateExpectedEqualsLocations (sourceNode) {
+    const declarations = sourceNode.parent.body.filter((node) => {
+      const isDeclaration = node.type === 'VariableDeclaration';
+      const isInSourceBlock = node.loc.start.line >= sourceNode.loc.start.line;
+      const declaration = node.declarations[0];
+
+      return isDeclaration && isInSourceBlock && (isRequire(declaration) || isFactoryBuild(declaration));
+    });
+    const linesInBlock = [];
+    let prevNode;
+
+    const expectedEqualsLocation = declarations.reduce((maxLoc, node) => {
+      if (prevNode && prevNode.loc.start.line + 1 < node.loc.start.line) {
+        return maxLoc;
+      }
+      linesInBlock.push(node.loc.start.line - 1);
+      prevNode = node;
+
+      const declaration = node.declarations[0];
+
+      const variableToken = declaration.id;
+      const newLoc = variableToken.loc.end.column + 1;
+
+      return maxLoc < newLoc ? newLoc : maxLoc;
+    }, 0);
+
+    linesInBlock.forEach((line) => {
+      expectedEqualsLocations[line] = expectedEqualsLocation;
+    });
+  }
+
+  return {
+    VariableDeclaration: (node) => {
+      const declaration = node.declarations[0];
+
+      if (!isRequire(declaration) && !isFactoryBuild(declaration)) {
+        return;
+      }
+
+      const variableToken = declaration.id;
+      const equalToken = getNextEqual(variableToken);
+      const nextToken = ctx.getTokenAfter(equalToken);
+      const line = variableToken.loc.start.line - 1;
+
+      if (typeof expectedEqualsLocations[line] === 'undefined') {
+        populateExpectedEqualsLocations(node);
+      }
+
+      const beforeDiff = equalToken.loc.start.column - expectedEqualsLocations[line];
+
+      if (beforeDiff !== 0) {
+        ctx.report(node, equalToken.loc.start, ERROR_MESSAGE, {
+          error: beforeDiff > 0 ? 'Extra' : 'Missing',
+          plural: Math.abs(beforeDiff) === 1 ? 'space' : 'spaces',
+          position: 'before',
+          variable: variableToken.name
+        });
+      }
+
+      const afterDiff = nextToken.loc.start.column - (equalToken.loc.start.column + 2);
+
+      if (afterDiff !== 0) {
+        ctx.report(node, nextToken.loc.start, ERROR_MESSAGE, {
+          error: afterDiff > 0 ? 'Extra' : 'Missing',
+          plural: Math.abs(afterDiff) === 1 ? 'space' : 'spaces',
+          position: 'after',
+          variable: variableToken.name
+        });
+      }
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "coveralls": "^2.11.6",
     "eslint": "^1.10.3",
     "eslint-config-lob": "^2.0.0",
     "generate-changelog": "^1.0.0",

--- a/test/rules/align-equals.test.js
+++ b/test/rules/align-equals.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+
+const Rule = require('../../lib/rules/align-equals');
+
+const Tester = new RuleTester({ ecmaFeatures: { blockBindings: true } });
+
+Tester.run('align-equals', Rule, {
+  valid: [
+    'let a = require("a");',
+    'let a = require("a");\nlet b = require("b");',
+    'let ab = require("ab");\nlet b  = require("b");',
+    'let a  = require("a");\nlet ab = require("ab");',
+    'let a = require("a");\n\nlet ab = require("ab");',
+    'let a = Factory.build("a");',
+    'let a = Factory.build("a");\nlet b = Factory.build("b");',
+    'let ab = Factory.build("ab");\nlet b  = Factory.build("b");',
+    'let a  = Factory.build("a");\nlet ab = Factory.build("ab");',
+    'let a = Factory.build("a");\n\nlet ab = Factory.build("ab");',
+    'let a = "a";\nlet ab = "ab";'
+  ],
+  invalid: [{
+    code: 'let a  = require("a");',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a   = require("a");',
+    errors: [{ message: 'Extra spaces before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a= require("a");',
+    errors: [{ message: 'Missing space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =  require("a");',
+    errors: [{ message: 'Extra space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =   require("a");',
+    errors: [{ message: 'Extra spaces after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =require("a");',
+    errors: [{ message: 'Missing space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = require("a");\nlet b = require("b");',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = require("a");\nlet b  = require("b");',
+    errors: [
+      { message: 'Extra space before equals for variable \'a\'.', line: 1 },
+      { message: 'Extra space before equals for variable \'b\'.', line: 2 }
+    ]
+  }, {
+    code: 'let a = require("a");\nlet b  = require("b");',
+    errors: [{ message: 'Extra space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = require("ab");\nlet b = require("b");',
+    errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = require("ab");\nlet b  = require("b");\n\nlet c  = require("c");',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = require("c");',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let a  = Factory.build("a");',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a   = Factory.build("a");',
+    errors: [{ message: 'Extra spaces before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a= Factory.build("a");',
+    errors: [{ message: 'Missing space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =  Factory.build("a");',
+    errors: [{ message: 'Extra space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =   Factory.build("a");',
+    errors: [{ message: 'Extra spaces after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =Factory.build("a");',
+    errors: [{ message: 'Missing space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = Factory.build("a");\nlet b = Factory.build("b");',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = Factory.build("a");\nlet b  = Factory.build("b");',
+    errors: [
+      { message: 'Extra space before equals for variable \'a\'.', line: 1 },
+      { message: 'Extra space before equals for variable \'b\'.', line: 2 }
+    ]
+  }, {
+    code: 'let a = Factory.build("a");\nlet b  = Factory.build("b");',
+    errors: [{ message: 'Extra space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = Factory.build("ab");\nlet b = Factory.build("b");',
+    errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = Factory.build("ab");\nlet b  = Factory.build("b");\n\nlet c  = Factory.build("c");',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = Factory.build("c");',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }]
+});


### PR DESCRIPTION
### What

Add the `align-requires` rule which enforces that all variable declarations involving `require` or `Factory.build`. This is (loosely) based on the [`key-spacing`](https://github.com/eslint/eslint/blob/master/lib/rules/key-spacing.js) rule which aligns colons in object declarations. This rule makes this valid:

```js
let a   = require('a');
let ab  = require('ab');
let abc = require('abc');

let b  = Factory.build('b');
let bc = Factory.build('c');

let x = 1;
let xy = 2;
let xyz = 3;
```

And this invalid (only shown with `require`s, but also applied to `Factory.build`s):

```js
let a  = require('a'); // error
let ab  = require('ab');
let abc = require('abc');

let b  = require('b'); // error

let c= require('c'); // error

let d =require('d'); // error

let e =  require('e'); // error

let f  = require('f'); // error
let g  = require('g'); // error
```

### Details

The main premise of this rule is relying on a cache of expected locations of equal signs (`expectedEqualsLocations`). If there's ever a line that isn't in the cache, it goes through and calculates the expected position based on the "variable declaration block" (on lines 73-75). For example, as it parses each of the following lines, you can see what `expectedEqualsLocations` looks like _after_ parsing the line:

```js
1: // expectedEqualsLocations = []
2: let a = require('a'); // expectedEqualsLocations = [undefined, 8, 8, 8]
3: let ab = require('ab'); // expectedEqualsLocations = [undefined, 8, 8, 8]
4: let abc = require('abc'); // expectedEqualsLocations = [undefined, 8, 8, 8]
5: 
6: let b = require('b'); // expectedEqualsLocations = [undefined, 8, 8, 8, undefined, 6, 6]
7: let c = require('c'); // expectedEqualsLocations = [undefined, 8, 8, 8, undefined, 6, 6]
```

So the "computation" of where the equal sign should be only happens once per block. I also didn't want to iterate of an array at any time to search for previously determined blocks, so that ruled out:

```js
expectedEqualsLocations = [{
  start: 2,
  end: 4,
  location: 8
}, {
  start: 6,
  end: 7,
  location: 6
}]
```

Because this structure would require iteration and comparing with each cached block which would be slower than a direct array lookup.

Knowing this, the rest should be pretty straight forward, but if anything it's clear, just let me know!

@mgartner 