### PR TITLE
fix(align-equals): consider MemberExpressions as well

### DIFF
--- a/lib/rules/align-equals.js
+++ b/lib/rules/align-equals.js
@@ -8,6 +8,18 @@ function isDirectRequire (declaration) {
     declaration.init.callee.name === 'require';
 }
 
+function isFunctionRequire (declaration) {
+  if (declaration.init && declaration.init.type === 'CallExpression') {
+    let callee = declaration.init.callee;
+
+    while (callee.type === 'CallExpression') {
+      callee = callee.callee;
+    }
+
+    return callee.name === 'require'
+  }
+}
+
 function isPropertyRequire (declaration) {
   return declaration.init &&
     declaration.init.type === 'MemberExpression' &&
@@ -16,7 +28,7 @@ function isPropertyRequire (declaration) {
 }
 
 function isRequire (declaration) {
-  return isDirectRequire(declaration) || isPropertyRequire(declaration);
+  return isDirectRequire(declaration) || isPropertyRequire(declaration) || isFunctionRequire(declaration);
 }
 
 function isFactoryBuild (declaration) {

--- a/lib/rules/align-equals.js
+++ b/lib/rules/align-equals.js
@@ -2,10 +2,21 @@
 
 const ERROR_MESSAGE = '{{error}} {{plural}} {{position}} equals for variable \'{{variable}}\'.';
 
-function isRequire (declaration) {
+function isDirectRequire (declaration) {
   return declaration.init &&
     declaration.init.type === 'CallExpression' &&
     declaration.init.callee.name === 'require';
+}
+
+function isPropertyRequire (declaration) {
+  return declaration.init &&
+    declaration.init.type === 'MemberExpression' &&
+    declaration.init.object.type === 'CallExpression' &&
+    declaration.init.object.callee.name === 'require';
+}
+
+function isRequire (declaration) {
+  return isDirectRequire(declaration) || isPropertyRequire(declaration);
 }
 
 function isFactoryBuild (declaration) {

--- a/lib/rules/align-equals.js
+++ b/lib/rules/align-equals.js
@@ -30,9 +30,8 @@ module.exports = function (ctx) {
     const declarations = sourceNode.parent.body.filter((node) => {
       const isDeclaration = node.type === 'VariableDeclaration';
       const isInSourceBlock = node.loc.start.line >= sourceNode.loc.start.line;
-      const declaration = node.declarations[0];
 
-      return isDeclaration && isInSourceBlock && (isRequire(declaration) || isFactoryBuild(declaration));
+      return isDeclaration && isInSourceBlock && (isRequire(node.declarations[0]) || isFactoryBuild(node.declarations[0]));
     });
     const linesInBlock = [];
     let prevNode;

--- a/lib/rules/padded-describes.js
+++ b/lib/rules/padded-describes.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ERROR_MESSAGE = 'Describe blocks must be padded by blank lines.';
+const ERROR_MESSAGE = 'Missing new line at the {{position}} of a describe block.';
 
 function isFunctionExpression (nodeType) {
   return nodeType === 'FunctionExpression' || nodeType === 'ArrowFunctionExpression';
@@ -65,15 +65,13 @@ module.exports = function (ctx) {
         const blockHasBottomPadding = isBlockBottomPadded(node);
 
         if (!blockHasTopPadding) {
-          ctx.report(node, ERROR_MESSAGE);
+          ctx.report(node, ERROR_MESSAGE, { position: 'top' });
         }
 
         if (!blockHasBottomPadding) {
-          ctx.report({
-            node,
-            loc: { line: node.loc.end.line, column: node.loc.end.column - 1 },
-            message: ERROR_MESSAGE
-          });
+          const loc = { line: node.loc.end.line, column: node.loc.end.column - 1 };
+
+          ctx.report(node, loc, ERROR_MESSAGE, { position: 'bottom' });
         }
       }
     }

--- a/lib/rules/padded-describes.js
+++ b/lib/rules/padded-describes.js
@@ -2,43 +2,21 @@
 
 const ERROR_MESSAGE = 'Describe blocks must be padded by blank lines.';
 
-/**
- * Determine if provided nodeType is a function type.
- * @private
- * @param {String} nodeType - type to test
- * @returns {Boolean} true if `nodeType` is a function type
- */
 function isFunctionExpression (nodeType) {
   return nodeType === 'FunctionExpression' || nodeType === 'ArrowFunctionExpression';
 }
 
-/**
- * Checks if the given non empty block node is the callback of a describe function.
- * @param {ASTNode} node - the AST node of a BlockStatement
- * @returns {Boolean} whether or not the block is the callback of a describe function
- */
 function isDescribeBlock (node) {
   return isFunctionExpression(node.parent.type) &&
     node.parent.parent.type === 'CallExpression' &&
     node.parent.parent.callee.name === 'describe';
 }
 
-/**
- * Checks if the location of a node or token is before the location of another node or token.
- * @param {ASTNode|Token} a - the node or token to check if its location is before b
- * @param {ASTNode|Token} b - the node or token which will be compared with a
- * @returns {Boolean} true if a is located before b
- */
 function isLocatedBefore (a, b) {
   return a.range[1] < b.range[0];
 }
 
 module.exports = function (ctx) {
-  /**
-   * Checks if the given non empty block node has a blank line before its first child node.
-   * @param {ASTNode} node - the AST node of a BlockStatement
-   * @returns {Boolean} whether or not the block starts with a blank line
-   */
   function isBlockTopPadded (node) {
     const blockStart = node.loc.start.line;
     const first = node.body[0];
@@ -59,11 +37,6 @@ module.exports = function (ctx) {
     return expectedFirstLine <= firstLine;
   }
 
-  /**
-   * Checks if the given non empty block node has a blank line after its last child node.
-   * @param {ASTNode} node - the AST node of a BlockStatement
-   * @returns {Boolean} whether or not the block ends with a blank line
-   */
   function isBlockBottomPadded (node) {
     const blockEnd = node.loc.end.line;
     const last = node.body[node.body.length - 1];

--- a/test/rules/align-equals.test.js
+++ b/test/rules/align-equals.test.js
@@ -13,6 +13,11 @@ Tester.run('align-equals', Rule, {
     'let ab = require("ab");\nlet b  = require("b");',
     'let a  = require("a");\nlet ab = require("ab");',
     'let a = require("a");\n\nlet ab = require("ab");',
+    'let a = require("a").a;',
+    'let a = require("a").a;\nlet b = require("b").b;',
+    'let ab = require("ab").ab;\nlet b  = require("b").b;',
+    'let a  = require("a").a;\nlet ab = require("ab").ab;',
+    'let a = require("a").a;\n\nlet ab = require("ab").ab;',
     'let a = Factory.build("a");',
     'let a = Factory.build("a");\nlet b = Factory.build("b");',
     'let ab = Factory.build("ab");\nlet b  = Factory.build("b");',
@@ -59,6 +64,48 @@ Tester.run('align-equals', Rule, {
   }, {
     code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = require("c");',
     errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let a  = require("a").a;',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a   = require("a").a;',
+    errors: [{ message: 'Extra spaces before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a= require("a").a;',
+    errors: [{ message: 'Missing space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =  require("a").a;',
+    errors: [{ message: 'Extra space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =   require("a").a;',
+    errors: [{ message: 'Extra spaces after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =require("a").a;',
+    errors: [{ message: 'Missing space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = require("a").a;\nlet b = require("b").b;',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = require("a").a;\nlet b  = require("b").b;',
+    errors: [
+      { message: 'Extra space before equals for variable \'a\'.', line: 1 },
+      { message: 'Extra space before equals for variable \'b\'.', line: 2 }
+    ]
+  }, {
+    code: 'let a = require("a").a;\nlet b  = require("b").b;',
+    errors: [{ message: 'Extra space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = require("ab").ab;\nlet b = require("b").b;',
+    errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = require("ab").ab;\nlet b  = require("b").b;\n\nlet c  = require("c").c;',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = require("c").c;',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let ab = require("ab").ab;\nlet b = require("b");',
+    errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
   }, {
     code: 'let a  = Factory.build("a");',
     errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]

--- a/test/rules/align-equals.test.js
+++ b/test/rules/align-equals.test.js
@@ -18,6 +18,11 @@ Tester.run('align-equals', Rule, {
     'let ab = require("ab").ab;\nlet b  = require("b").b;',
     'let a  = require("a").a;\nlet ab = require("ab").ab;',
     'let a = require("a").a;\n\nlet ab = require("ab").ab;',
+    'let a = require("a")();',
+    'let a = require("a")();\nlet b = require("b")();',
+    'let ab = require("ab")();\nlet b  = require("b")();',
+    'let a  = require("a")();\nlet ab = require("ab")();',
+    'let a = require("a")();\n\nlet ab = require("ab")();',
     'let a = Factory.build("a");',
     'let a = Factory.build("a");\nlet b = Factory.build("b");',
     'let ab = Factory.build("ab");\nlet b  = Factory.build("b");',
@@ -104,7 +109,52 @@ Tester.run('align-equals', Rule, {
     code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = require("c").c;',
     errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
   }, {
+    code: 'let a  = require("a")();',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a   = require("a")();',
+    errors: [{ message: 'Extra spaces before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a= require("a")();',
+    errors: [{ message: 'Missing space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =  require("a")();',
+    errors: [{ message: 'Extra space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =   require("a")();',
+    errors: [{ message: 'Extra spaces after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =require("a")();',
+    errors: [{ message: 'Missing space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = require("a")();\nlet b = require("b")();',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = require("a")();\nlet b  = require("b")();',
+    errors: [
+      { message: 'Extra space before equals for variable \'a\'.', line: 1 },
+      { message: 'Extra space before equals for variable \'b\'.', line: 2 }
+    ]
+  }, {
+    code: 'let a = require("a")();\nlet b  = require("b")();',
+    errors: [{ message: 'Extra space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = require("ab")();\nlet b = require("b")();',
+    errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = require("ab")();\nlet b  = require("b")();\n\nlet c  = require("c")();',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = require("c")();',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let a  = require("a")()();',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
     code: 'let ab = require("ab").ab;\nlet b = require("b");',
+    errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = require("ab")();\nlet b = require("b");',
     errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
   }, {
     code: 'let a  = Factory.build("a");',

--- a/test/rules/padded-describes.test.js
+++ b/test/rules/padded-describes.test.js
@@ -6,7 +6,8 @@ const Rule = require('../../lib/rules/padded-describes');
 
 const Tester = new RuleTester({ ecmaFeatures: { arrowFunctions: true } });
 
-const ERROR_MESSAGE = 'Describe blocks must be padded by blank lines.';
+const TOP_ERROR_MESSAGE    = 'Missing new line at the top of a describe block.';
+const BOTTOM_ERROR_MESSAGE = 'Missing new line at the bottom of a describe block.';
 
 Tester.run('padded-describes', Rule, {
   valid: [
@@ -26,39 +27,39 @@ Tester.run('padded-describes', Rule, {
   ],
   invalid: [{
     code: 'describe("", function () { var a = ""; });',
-    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 1 }]
+    errors: [{ message: TOP_ERROR_MESSAGE, line: 1 }, { message: BOTTOM_ERROR_MESSAGE, line: 1 }]
   }, {
     code: 'describe("", function () {\nvar a = "";\n});',
-    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 3 }]
+    errors: [{ message: TOP_ERROR_MESSAGE, line: 1 }, { message: BOTTOM_ERROR_MESSAGE, line: 3 }]
   }, {
     code: 'describe("", function () {\n\nvar a = "";\n});',
-    errors: [{ message: ERROR_MESSAGE }]
+    errors: [{ message: BOTTOM_ERROR_MESSAGE, line: 4 }]
   }, {
     code: 'describe("", function () {\nvar a = "";\n\n});',
-    errors: [{ message: ERROR_MESSAGE }]
+    errors: [{ message: TOP_ERROR_MESSAGE, line: 1 }]
   }, {
     code: 'describe("", function () {\n// comment\nvar a = "";\n});',
-    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 4 }]
+    errors: [{ message: TOP_ERROR_MESSAGE, line: 1 }, { message: BOTTOM_ERROR_MESSAGE, line: 4 }]
   }, {
     code: 'describe("", function () {\n/* comment */ var a = "";\n});',
-    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 3 }]
+    errors: [{ message: TOP_ERROR_MESSAGE, line: 1 }, { message: BOTTOM_ERROR_MESSAGE, line: 3 }]
   }, {
     code: 'describe("", function () {\nvar a = "";\n// comment\n});',
-    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 4 }]
+    errors: [{ message: TOP_ERROR_MESSAGE, line: 1 }, { message: BOTTOM_ERROR_MESSAGE, line: 4 }]
   }, {
     code: 'describe("", function () {\nvar a = ""; /* comment */\n});',
-    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 3 }]
+    errors: [{ message: TOP_ERROR_MESSAGE, line: 1 }, { message: BOTTOM_ERROR_MESSAGE, line: 3 }]
   }, {
     code: 'describe("", () => { var a = ""; });',
-    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 1 }]
+    errors: [{ message: TOP_ERROR_MESSAGE, line: 1 }, { message: BOTTOM_ERROR_MESSAGE, line: 1 }]
   }, {
     code: 'describe("", () => {\nvar a = "";\n});',
-    errors: [{ message: ERROR_MESSAGE, line: 1 }, { message: ERROR_MESSAGE, line: 3 }]
+    errors: [{ message: TOP_ERROR_MESSAGE, line: 1 }, { message: BOTTOM_ERROR_MESSAGE, line: 3 }]
   }, {
     code: 'describe("", () => {\n\nvar a = "";\n});',
-    errors: [{ message: ERROR_MESSAGE }]
+    errors: [{ message: BOTTOM_ERROR_MESSAGE, line: 4 }]
   }, {
     code: 'describe("", () => {\nvar a = "";\n\n});',
-    errors: [{ message: ERROR_MESSAGE }]
+    errors: [{ message: TOP_ERROR_MESSAGE, line: 1 }]
   }]
 });


### PR DESCRIPTION
### What

* Fix `align-equals`
  * Prevent a possible syntax error
  * Consider `MemberExpression`s
* Fix `padded-describes`
  * Remove JSDocs
  * Make the error message more specific

### Why

The first issue with `align-equals` is the possible syntax error that could happen if `node.declarations` is `undefined` if the `node.type` is not `VariableDeclaration` because I tried to extract a variable prematurely.

The second issue fixed is for special `require`s that accesses a property of that `require`, e.g.

```js
const Knex = require('../../db').knex;
```

I found it by running these rules against API and noticing some false errors. It's because the AST structure of this special `require` is different than a normal `require`. I'm now checking if it matches either of these structures.

I'm also removing the JSDocs in `padded-describes` since there aren't any JSDocs in any of the other files. I think it's a bit unnecessary since the function names are self-documenting.

Also when running `padded-describes` vs `align-equals` against API, the error message for `align-equals` is much more descriptive (since I knew more about eslint when I made it). This just makes `padded-describes` descriptive as well.

@mgartner 