### PR TITLE
fix(align-equals): account for promisification when aligning

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then configure the rules you want to use under the rules section.
 
 ## Supported Rules
 
-* `align-equals` - equal signs of variable declarations involving `require` or `Factory.build` must be aligned
+* `align-equals` - equal signs of variable declarations involving `require`, `Factory.build`, `Bluebird.promisify`, or `Bluebird.promisifyAll` must be aligned
 * `newline-after-mocha` - new lines must be between mocha blocks (`describe`, `it`, `beforeEach`, etc)
 * `padded-describes` - `describe` blocks must be padded by blank lines
 

--- a/lib/rules/align-equals.js
+++ b/lib/rules/align-equals.js
@@ -16,7 +16,7 @@ function isFunctionRequire (declaration) {
       callee = callee.callee;
     }
 
-    return callee.name === 'require'
+    return callee.name === 'require';
   }
 }
 
@@ -38,6 +38,18 @@ function isFactoryBuild (declaration) {
     declaration.init.callee.property && declaration.init.callee.property.name === 'build';
 }
 
+function isPromisification (declaration) {
+  return declaration.init &&
+    declaration.init.type === 'CallExpression' &&
+    declaration.init.callee.object && declaration.init.callee.object.name === 'Bluebird' &&
+    declaration.init.callee.property &&
+    (declaration.init.callee.property.name === 'promisify' || declaration.init.callee.property.name === 'promisifyAll');
+}
+
+function shouldBeAligned (declaration) {
+  return isRequire(declaration) || isFactoryBuild(declaration) || isPromisification(declaration);
+}
+
 module.exports = function (ctx) {
   const expectedEqualsLocations = [];
 
@@ -54,7 +66,7 @@ module.exports = function (ctx) {
       const isDeclaration = node.type === 'VariableDeclaration';
       const isInSourceBlock = node.loc.start.line >= sourceNode.loc.start.line;
 
-      return isDeclaration && isInSourceBlock && (isRequire(node.declarations[0]) || isFactoryBuild(node.declarations[0]));
+      return isDeclaration && isInSourceBlock && shouldBeAligned(node.declarations[0]);
     });
     const linesInBlock = [];
     let prevNode;
@@ -83,7 +95,7 @@ module.exports = function (ctx) {
     VariableDeclaration: (node) => {
       const declaration = node.declarations[0];
 
-      if (!isRequire(declaration) && !isFactoryBuild(declaration)) {
+      if (!shouldBeAligned(declaration)) {
         return;
       }
 

--- a/test/rules/align-equals.test.js
+++ b/test/rules/align-equals.test.js
@@ -23,6 +23,16 @@ Tester.run('align-equals', Rule, {
     'let ab = require("ab")();\nlet b  = require("b")();',
     'let a  = require("a")();\nlet ab = require("ab")();',
     'let a = require("a")();\n\nlet ab = require("ab")();',
+    'let a = Bluebird.promisifyAll(require("a"));',
+    'let a = Bluebird.promisifyAll(require("a"));\nlet b = Bluebird.promisifyAll(require("b"));',
+    'let ab = Bluebird.promisifyAll(require("ab"));\nlet b  = Bluebird.promisifyAll(require("b"));',
+    'let a  = Bluebird.promisifyAll(require("a"));\nlet ab = Bluebird.promisifyAll(require("ab"));',
+    'let a = Bluebird.promisifyAll(require("a"));\n\nlet ab = Bluebird.promisifyAll(require("ab"));',
+    'let a = Bluebird.promisify(require("a").a);',
+    'let a = Bluebird.promisify(require("a").a);\nlet b = Bluebird.promisify(require("b").b);',
+    'let ab = Bluebird.promisify(require("ab").ab);\nlet b  = Bluebird.promisify(require("b").b);',
+    'let a  = Bluebird.promisify(require("a").a);\nlet ab = Bluebird.promisify(require("ab").ab);',
+    'let a = Bluebird.promisify(require("a").a);\n\nlet ab = Bluebird.promisify(require("ab").ab);',
     'let a = Factory.build("a");',
     'let a = Factory.build("a");\nlet b = Factory.build("b");',
     'let ab = Factory.build("ab");\nlet b  = Factory.build("b");',
@@ -148,6 +158,84 @@ Tester.run('align-equals', Rule, {
     code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = require("c")();',
     errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
   }, {
+    code: 'let a  = Bluebird.promisifyAll(require("a"));',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a   = Bluebird.promisifyAll(require("a"));',
+    errors: [{ message: 'Extra spaces before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a= Bluebird.promisifyAll(require("a"));',
+    errors: [{ message: 'Missing space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =  Bluebird.promisifyAll(require("a"));',
+    errors: [{ message: 'Extra space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =   Bluebird.promisifyAll(require("a"));',
+    errors: [{ message: 'Extra spaces after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =Bluebird.promisifyAll(require("a"));',
+    errors: [{ message: 'Missing space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = Bluebird.promisifyAll(require("a"));\nlet b = Bluebird.promisifyAll(require("b"));',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = Bluebird.promisifyAll(require("a"));\nlet b  = Bluebird.promisifyAll(require("b"));',
+    errors: [
+      { message: 'Extra space before equals for variable \'a\'.', line: 1 },
+      { message: 'Extra space before equals for variable \'b\'.', line: 2 }
+    ]
+  }, {
+    code: 'let a = Bluebird.promisifyAll(require("a"));\nlet b  = Bluebird.promisifyAll(require("b"));',
+    errors: [{ message: 'Extra space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = Bluebird.promisifyAll(require("ab"));\nlet b = Bluebird.promisifyAll(require("b"));',
+    errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = Bluebird.promisifyAll(require("ab"));\nlet b  = Bluebird.promisifyAll(require("b"));\n\nlet c  = Bluebird.promisifyAll(require("c"));',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = Bluebird.promisifyAll(require("c"));',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let a  = Bluebird.promisify(require("a").a);',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a   = Bluebird.promisify(require("a").a);',
+    errors: [{ message: 'Extra spaces before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a= Bluebird.promisify(require("a").a);',
+    errors: [{ message: 'Missing space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =  Bluebird.promisify(require("a").a);',
+    errors: [{ message: 'Extra space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =   Bluebird.promisify(require("a").a);',
+    errors: [{ message: 'Extra spaces after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =Bluebird.promisify(require("a").a);',
+    errors: [{ message: 'Missing space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = Bluebird.promisify(require("a").a);\nlet b = Bluebird.promisify(require("b").b);',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = Bluebird.promisify(require("a").a);\nlet b  = Bluebird.promisify(require("b").b);',
+    errors: [
+      { message: 'Extra space before equals for variable \'a\'.', line: 1 },
+      { message: 'Extra space before equals for variable \'b\'.', line: 2 }
+    ]
+  }, {
+    code: 'let a = Bluebird.promisify(require("a").a);\nlet b  = Bluebird.promisify(require("b").b);',
+    errors: [{ message: 'Extra space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = Bluebird.promisify(require("ab").ab);\nlet b = Bluebird.promisify(require("b").b);',
+    errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = Bluebird.promisify(require("ab").ab);\nlet b  = Bluebird.promisify(require("b").b);\n\nlet c  = Bluebird.promisify(require("c").c);',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = Bluebird.promisify(require("c").c);',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
     code: 'let a  = require("a")()();',
     errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
   }, {
@@ -155,6 +243,12 @@ Tester.run('align-equals', Rule, {
     errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
   }, {
     code: 'let ab = require("ab")();\nlet b = require("b");',
+    errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = Bluebird.promisifyAll(require("ab"));\nlet b = require("b");',
+    errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = Bluebird.promisify(require("ab").ab);\nlet b = require("b");',
     errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
   }, {
     code: 'let a  = Factory.build("a");',


### PR DESCRIPTION
### What & Why

Align all calls to `Bluebird.promisify` and `Bluebird.promisifyAll`. Since we usually do this at the top and with `require`s inside them, it would be nice if they are accounted for in the lint as well.