### PR TITLE
fix(align-equals): align named factories as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then configure the rules you want to use under the rules section.
 
 ## Supported Rules
 
-* `align-equals` - equal signs of variable declarations involving `require`, `Factory.build`, `Bluebird.promisify`, or `Bluebird.promisifyAll` must be aligned
+* `align-equals` - equal signs of variable declarations involving `require`, `Factory.build` (including named factories like `UserFactory.build`), `Bluebird.promisify`, or `Bluebird.promisifyAll` must be aligned
 * `newline-after-mocha` - new lines must be between mocha blocks (`describe`, `it`, `beforeEach`, etc)
 * `padded-describes` - `describe` blocks must be padded by blank lines
 

--- a/lib/rules/align-equals.js
+++ b/lib/rules/align-equals.js
@@ -34,7 +34,7 @@ function isRequire (declaration) {
 function isFactoryBuild (declaration) {
   return declaration.init &&
     declaration.init.type === 'CallExpression' &&
-    declaration.init.callee.object && declaration.init.callee.object.name === 'Factory' &&
+    declaration.init.callee.object && declaration.init.callee.object.name && declaration.init.callee.object.name.includes('Factory') &&
     declaration.init.callee.property && declaration.init.callee.property.name === 'build';
 }
 

--- a/test/rules/align-equals.test.js
+++ b/test/rules/align-equals.test.js
@@ -38,6 +38,11 @@ Tester.run('align-equals', Rule, {
     'let ab = Factory.build("ab");\nlet b  = Factory.build("b");',
     'let a  = Factory.build("a");\nlet ab = Factory.build("ab");',
     'let a = Factory.build("a");\n\nlet ab = Factory.build("ab");',
+    'let a = NamedFactory.build();',
+    'let a = NamedFactory.build();\nlet b = NamedFactory.build();',
+    'let ab = NamedFactory.build();\nlet b  = NamedFactory.build();',
+    'let a  = NamedFactory.build();\nlet ab = NamedFactory.build();',
+    'let a = NamedFactory.build();\n\nlet ab = NamedFactory.build();',
     'let a = "a";\nlet ab = "ab";'
   ],
   invalid: [{
@@ -272,22 +277,61 @@ Tester.run('align-equals', Rule, {
     code: 'let a  = Factory.build("a");\nlet b = Factory.build("b");',
     errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
   }, {
-    code: 'let a  = Factory.build("a");\nlet b  = Factory.build("b");',
+    code: 'let a  = NamedFactory.build();\nlet b  = NamedFactory.build();',
     errors: [
       { message: 'Extra space before equals for variable \'a\'.', line: 1 },
       { message: 'Extra space before equals for variable \'b\'.', line: 2 }
     ]
   }, {
-    code: 'let a = Factory.build("a");\nlet b  = Factory.build("b");',
+    code: 'let a = NamedFactory.build();\nlet b  = NamedFactory.build();',
     errors: [{ message: 'Extra space before equals for variable \'b\'.', line: 2 }]
   }, {
-    code: 'let ab = Factory.build("ab");\nlet b = Factory.build("b");',
+    code: 'let ab = NamedFactory.build();\nlet b = NamedFactory.build();',
     errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
   }, {
-    code: 'let ab = Factory.build("ab");\nlet b  = Factory.build("b");\n\nlet c  = Factory.build("c");',
+    code: 'let ab = NamedFactory.build();\nlet b  = NamedFactory.build();\n\nlet c  = NamedFactory.build();',
     errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
   }, {
-    code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = Factory.build("c");',
+    code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = NamedFactory.build();',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let a  = NamedFactory.build();',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a   = NamedFactory.build();',
+    errors: [{ message: 'Extra spaces before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a= NamedFactory.build();',
+    errors: [{ message: 'Missing space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =  NamedFactory.build();',
+    errors: [{ message: 'Extra space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =   NamedFactory.build();',
+    errors: [{ message: 'Extra spaces after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a =NamedFactory.build();',
+    errors: [{ message: 'Missing space after equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = NamedFactory.build();\nlet b = NamedFactory.build();',
+    errors: [{ message: 'Extra space before equals for variable \'a\'.', line: 1 }]
+  }, {
+    code: 'let a  = NamedFactory.build();\nlet b  = NamedFactory.build();',
+    errors: [
+      { message: 'Extra space before equals for variable \'a\'.', line: 1 },
+      { message: 'Extra space before equals for variable \'b\'.', line: 2 }
+    ]
+  }, {
+    code: 'let a = NamedFactory.build();\nlet b  = NamedFactory.build();',
+    errors: [{ message: 'Extra space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = NamedFactory.build();\nlet b = NamedFactory.build();',
+    errors: [{ message: 'Missing space before equals for variable \'b\'.', line: 2 }]
+  }, {
+    code: 'let ab = NamedFactory.build();\nlet b  = NamedFactory.build();\n\nlet c  = NamedFactory.build();',
+    errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
+  }, {
+    code: 'let ab = "ab";\nlet b = "b";\n\nlet c  = NamedFactory.build();',
     errors: [{ message: 'Extra space before equals for variable \'c\'.', line: 4 }]
   }]
 });


### PR DESCRIPTION
### What & Why

Sometimes in our codebase, we export factories and `require` them to be used in tests instead of relying on the global `Factory` object. This results in the following code:

```js
const UserFactory = require('../factories/user');

const user = UserFactory.build();
```

This PR also considers `*Factory` variables when checking for alignment.