### PR TITLE
feat(eslint): loosen eslint peer dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 node_js:
   - '4'
   - '5'
+before_install:
+  - npm i npm@3 -g
 script:
   - npm test
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mocha": "^2.4.5"
   },
   "peerDependencies": {
-    "eslint": "1.x"
+    "eslint": ">=0.8.0"
   },
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
### What & Why

As opposed to restricting the eslint version to v1.x, we really should be allowing everything above v0.8.0 (which is the version that introduced the plugin API) since that's what's recommended in [the documentation](http://eslint.org/docs/developer-guide/working-with-plugins#peer-dependency). There haven't been any plugin breaking changes throughout eslint so everything should be compatible.

I'd like to update the eslint version that's actually included in the repo (from v1.10.3 to the latest), but there's a slight chicken and the egg problem here because `eslint-plugin-lob` requires eslint v1.x and depends on `eslint-config-lob` and `eslint-config-lob` also requires eslint v1.x and depends on `eslint-plugin-lob`. So if I try to update the version of eslint in `plugin`, it'll complain because `config` isn't compatible, but if I try to update `config`, it's complain that `plugin` isn't compatible. So I'll be releasing a new version of this repo with just the peer dependency lifted and then I'll be able to update `config` to work with the eslint v3.x (which will require changes) which will then allow the dev dependency of `plugin` to be updated.