### PR TITLE
refactor(node): support node < v4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "lob"
+  "extends": "lob/es5"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: node_js
 sudo: false
 node_js:
+  - '0.10'
+  - '0.12'
   - '4'
   - '5'
+  - '6'
+  - '7'
+  - '8'
 before_install:
   - npm i npm@3 -g
 script:

--- a/lib/rules/align-equals.js
+++ b/lib/rules/align-equals.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ERROR_MESSAGE = '{{error}} {{plural}} {{position}} equals for variable \'{{variable}}\'.';
+var ERROR_MESSAGE = '{{error}} {{plural}} {{position}} equals for variable \'{{variable}}\'.';
 
 function isDirectRequire (declaration) {
   return declaration.init &&
@@ -10,7 +10,7 @@ function isDirectRequire (declaration) {
 
 function isFunctionRequire (declaration) {
   if (declaration.init && declaration.init.type === 'CallExpression') {
-    let callee = declaration.init.callee;
+    var callee = declaration.init.callee;
 
     while (callee.type === 'CallExpression') {
       callee = callee.callee;
@@ -34,7 +34,7 @@ function isRequire (declaration) {
 function isFactoryBuild (declaration) {
   return declaration.init &&
     declaration.init.type === 'CallExpression' &&
-    declaration.init.callee.object && declaration.init.callee.object.name && declaration.init.callee.object.name.includes('Factory') &&
+    declaration.init.callee.object && declaration.init.callee.object.name && declaration.init.callee.object.name.indexOf('Factory') !== -1 &&
     declaration.init.callee.property && declaration.init.callee.property.name === 'build';
 }
 
@@ -51,7 +51,7 @@ function shouldBeAligned (declaration) {
 }
 
 module.exports = function (ctx) {
-  const expectedEqualsLocations = [];
+  var expectedEqualsLocations = [];
 
   function getNextEqual (node) {
     while (node && (node.type !== 'Punctuator' || node.value !== '=')) {
@@ -62,53 +62,53 @@ module.exports = function (ctx) {
   }
 
   function populateExpectedEqualsLocations (sourceNode) {
-    const declarations = sourceNode.parent.body.filter((node) => {
-      const isDeclaration = node.type === 'VariableDeclaration';
-      const isInSourceBlock = node.loc.start.line >= sourceNode.loc.start.line;
+    var declarations = sourceNode.parent.body.filter(function (node) {
+      var isDeclaration = node.type === 'VariableDeclaration';
+      var isInSourceBlock = node.loc.start.line >= sourceNode.loc.start.line;
 
       return isDeclaration && isInSourceBlock && shouldBeAligned(node.declarations[0]);
     });
-    const linesInBlock = [];
-    let prevNode;
+    var linesInBlock = [];
+    var prevNode;
 
-    const expectedEqualsLocation = declarations.reduce((maxLoc, node) => {
+    var expectedEqualsLocation = declarations.reduce(function (maxLoc, node) {
       if (prevNode && prevNode.loc.start.line + 1 < node.loc.start.line) {
         return maxLoc;
       }
       linesInBlock.push(node.loc.start.line - 1);
       prevNode = node;
 
-      const declaration = node.declarations[0];
+      var declaration = node.declarations[0];
 
-      const variableToken = declaration.id;
-      const newLoc = variableToken.loc.end.column + 1;
+      var variableToken = declaration.id;
+      var newLoc = variableToken.loc.end.column + 1;
 
       return maxLoc < newLoc ? newLoc : maxLoc;
     }, 0);
 
-    linesInBlock.forEach((line) => {
+    linesInBlock.forEach(function (line) {
       expectedEqualsLocations[line] = expectedEqualsLocation;
     });
   }
 
   return {
-    VariableDeclaration: (node) => {
-      const declaration = node.declarations[0];
+    VariableDeclaration: function (node) {
+      var declaration = node.declarations[0];
 
       if (!shouldBeAligned(declaration)) {
         return;
       }
 
-      const variableToken = declaration.id;
-      const equalToken = getNextEqual(variableToken);
-      const nextToken = ctx.getTokenAfter(equalToken);
-      const line = variableToken.loc.start.line - 1;
+      var variableToken = declaration.id;
+      var equalToken = getNextEqual(variableToken);
+      var nextToken = ctx.getTokenAfter(equalToken);
+      var line = variableToken.loc.start.line - 1;
 
       if (typeof expectedEqualsLocations[line] === 'undefined') {
         populateExpectedEqualsLocations(node);
       }
 
-      const beforeDiff = equalToken.loc.start.column - expectedEqualsLocations[line];
+      var beforeDiff = equalToken.loc.start.column - expectedEqualsLocations[line];
 
       if (beforeDiff !== 0) {
         ctx.report(node, equalToken.loc.start, ERROR_MESSAGE, {
@@ -119,7 +119,7 @@ module.exports = function (ctx) {
         });
       }
 
-      const afterDiff = nextToken.loc.start.column - (equalToken.loc.start.column + 2);
+      var afterDiff = nextToken.loc.start.column - (equalToken.loc.start.column + 2);
 
       if (afterDiff !== 0) {
         ctx.report(node, nextToken.loc.start, ERROR_MESSAGE, {

--- a/lib/rules/newline-after-mocha.js
+++ b/lib/rules/newline-after-mocha.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ERROR_MESSAGE = 'It and describe blocks must be separated by new lines.';
+var ERROR_MESSAGE = 'It and describe blocks must be separated by new lines.';
 
 function isMochaCall (node) {
   return node.callee.name === 'it' ||
@@ -17,8 +17,8 @@ function isLastNode (node) {
 
 module.exports = function (ctx) {
   return {
-    CallExpression: (node) => {
-      const statement = node.parent;
+    CallExpression: function (node) {
+      var statement = node.parent;
 
       if (!isMochaCall(node)) {
         return;
@@ -28,10 +28,10 @@ module.exports = function (ctx) {
         return;
       }
 
-      const lastToken = ctx.getLastToken(statement);
-      const nextToken = ctx.getTokenAfter(statement);
-      const expectedNextLineNum = lastToken.loc.end.line + 1;
-      const hasNewLine = nextToken.loc.start.line > expectedNextLineNum;
+      var lastToken = ctx.getLastToken(statement);
+      var nextToken = ctx.getTokenAfter(statement);
+      var expectedNextLineNum = lastToken.loc.end.line + 1;
+      var hasNewLine = nextToken.loc.start.line > expectedNextLineNum;
 
       if (!hasNewLine) {
         ctx.report(node, ERROR_MESSAGE, { identifier: node.name });

--- a/lib/rules/padded-describes.js
+++ b/lib/rules/padded-describes.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ERROR_MESSAGE = 'Missing new line at the {{position}} of a describe block.';
+var ERROR_MESSAGE = 'Missing new line at the {{position}} of a describe block.';
 
 function isFunctionExpression (nodeType) {
   return nodeType === 'FunctionExpression' || nodeType === 'ArrowFunctionExpression';
@@ -18,17 +18,17 @@ function isLocatedBefore (a, b) {
 
 module.exports = function (ctx) {
   function isBlockTopPadded (node) {
-    const blockStart = node.loc.start.line;
-    const first = node.body[0];
-    const expectedFirstLine = blockStart + 2;
-    const leadingComments = (first.leadingComments || []).slice();
-    let firstLine = first.loc.start.line;
+    var blockStart = node.loc.start.line;
+    var first = node.body[0];
+    var expectedFirstLine = blockStart + 2;
+    var leadingComments = (first.leadingComments || []).slice();
+    var firstLine = first.loc.start.line;
 
     while (leadingComments.length > 0 && leadingComments[0].loc.start.line <= node.loc.start.line) {
       leadingComments.shift();
     }
 
-    const firstComment = leadingComments[0];
+    var firstComment = leadingComments[0];
 
     if (firstComment && isLocatedBefore(firstComment, first)) {
       firstLine = firstComment.loc.start.line;
@@ -38,18 +38,18 @@ module.exports = function (ctx) {
   }
 
   function isBlockBottomPadded (node) {
-    const blockEnd = node.loc.end.line;
-    const last = node.body[node.body.length - 1];
-    const lastToken = ctx.getLastToken(last);
-    const expectedLastLine = blockEnd - 2;
-    const trailingComments = (last.trailingComments || []).slice();
-    let lastLine = lastToken.loc.end.line;
+    var blockEnd = node.loc.end.line;
+    var last = node.body[node.body.length - 1];
+    var lastToken = ctx.getLastToken(last);
+    var expectedLastLine = blockEnd - 2;
+    var trailingComments = (last.trailingComments || []).slice();
+    var lastLine = lastToken.loc.end.line;
 
     while (trailingComments.length > 0 && trailingComments[trailingComments.length - 1].loc.end.line >= node.loc.end.line) {
       trailingComments.pop();
     }
 
-    const lastComment = trailingComments[trailingComments.length - 1];
+    var lastComment = trailingComments[trailingComments.length - 1];
 
     if (lastComment && isLocatedBefore(lastToken, lastComment)) {
       lastLine = lastComment.loc.end.line;
@@ -59,17 +59,17 @@ module.exports = function (ctx) {
   }
 
   return {
-    BlockStatement: (node) => {
+    BlockStatement: function (node) {
       if (node.body.length > 0 && isDescribeBlock(node)) {
-        const blockHasTopPadding = isBlockTopPadded(node);
-        const blockHasBottomPadding = isBlockBottomPadded(node);
+        var blockHasTopPadding = isBlockTopPadded(node);
+        var blockHasBottomPadding = isBlockBottomPadded(node);
 
         if (!blockHasTopPadding) {
           ctx.report(node, ERROR_MESSAGE, { position: 'top' });
         }
 
         if (!blockHasBottomPadding) {
-          const loc = { line: node.loc.end.line, column: node.loc.end.column - 1 };
+          var loc = { line: node.loc.end.line, column: node.loc.end.column - 1 };
 
           ctx.report(node, loc, ERROR_MESSAGE, { position: 'bottom' });
         }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": ">=0.8.0"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=0.10.0"
   },
   "license": "MIT"
 }

--- a/test/rules/align-equals.test.js
+++ b/test/rules/align-equals.test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+var RuleTester = require('eslint').RuleTester;
 
-const Rule = require('../../lib/rules/align-equals');
+var Rule = require('../../lib/rules/align-equals');
 
-const Tester = new RuleTester({ ecmaFeatures: { blockBindings: true } });
+var Tester = new RuleTester({ ecmaFeatures: { blockBindings: true } });
 
 Tester.run('align-equals', Rule, {
   valid: [

--- a/test/rules/newline-after-mocha.test.js
+++ b/test/rules/newline-after-mocha.test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+var RuleTester = require('eslint').RuleTester;
 
-const Rule = require('../../lib/rules/newline-after-mocha');
+var Rule = require('../../lib/rules/newline-after-mocha');
 
-const Tester = new RuleTester({ ecmaFeatures: { arrowFunctions: true } });
+var Tester = new RuleTester({ ecmaFeatures: { arrowFunctions: true } });
 
-const ERROR_MESSAGE = 'It and describe blocks must be separated by new lines.';
+var ERROR_MESSAGE = 'It and describe blocks must be separated by new lines.';
 
 Tester.run('newline-after-mocha', Rule, {
   valid: [

--- a/test/rules/padded-describes.test.js
+++ b/test/rules/padded-describes.test.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+var RuleTester = require('eslint').RuleTester;
 
-const Rule = require('../../lib/rules/padded-describes');
+var Rule = require('../../lib/rules/padded-describes');
 
-const Tester = new RuleTester({ ecmaFeatures: { arrowFunctions: true } });
+var Tester = new RuleTester({ ecmaFeatures: { arrowFunctions: true } });
 
-const TOP_ERROR_MESSAGE    = 'Missing new line at the top of a describe block.';
-const BOTTOM_ERROR_MESSAGE = 'Missing new line at the bottom of a describe block.';
+var TOP_ERROR_MESSAGE    = 'Missing new line at the top of a describe block.';
+var BOTTOM_ERROR_MESSAGE = 'Missing new line at the bottom of a describe block.';
 
 Tester.run('padded-describes', Rule, {
   valid: [


### PR DESCRIPTION
### What & Why

We want to use this module in repos that still support 0.10 and 0.12 so this needs to be compatible with it.

The build is failing, but that's just because of recursive dependencies. Once this is merged and published, then a rebuild should solve this.